### PR TITLE
Draftable meditations

### DIFF
--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -13,6 +13,7 @@ module Admin
       untranslated SubtleSystemNode, :critical, &block
       needs_review StaticPage, :important, &block
       needs_review SubtleSystemNode, :important, &block
+      needs_review Meditation, :important, &block
       needs_review Treatment, :important, &block
       needs_review Article, :important, &block
       unpublished Article, :normal, &block
@@ -96,9 +97,11 @@ module Admin
           policy_scope(model).needs_review.each do |record|
             next unless record.ready_for_review?
             
+            action = record.contentable? ? :review : :edit
             block.call({
               model: model,
               name: record_name(record),
+              url: polymorphic_admin_path([action, :admin, record]),
               message: translate('admin.tags.unapproved_changes'),
               urgency: urgency,
             })

--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -99,8 +99,7 @@ module Admin
             block.call({
               model: model,
               name: record_name(record),
-              url: polymorphic_admin_path([:review, :admin, record]),
-              message: translate('admin.tags.unpublished_changes'),
+              message: translate('admin.tags.unapproved_changes'),
               urgency: urgency,
             })
           end

--- a/app/helpers/admin/input_helper.rb
+++ b/app/helpers/admin/input_helper.rb
@@ -77,7 +77,16 @@ module Admin::InputHelper
   end
 
   def draftable_field form, attribute, type: :string, label: true, disabled: false, input: {}, wrapper: {}, **args
-    key = (type == :association ? "#{attribute}_id" : attribute.to_s)
+    key = attribute.to_s
+
+    if type == :association
+      if key.pluralize != key && key.singularize == key # Singular
+        key = "#{key}_id"
+      else
+        key = "#{key.singularize}_ids"
+      end
+    end
+
     has_draft = args[:draft].present? || form.object.parsed_draft&.has_key?(key)
     value = args.key?(:value) ? args[:value] : form.object.send(key)
 

--- a/app/helpers/admin/permissions_helper.rb
+++ b/app/helpers/admin/permissions_helper.rb
@@ -38,7 +38,7 @@ module Admin
       },
 
       meditation: {
-        translator: [],
+        translator: %i[translate],
         writer: [],
         editor: [],
         regional_admin: %i[update publish create],

--- a/app/models/concerns/draftable.rb
+++ b/app/models/concerns/draftable.rb
@@ -41,9 +41,15 @@ module Draftable
   end
 
   def ready_for_review? section = nil
-    return false unless has_draft? && (parsed_draft['published'] == true || !respond_to?(:published) || published)
-    return false if section == :content && parsed_draft&.except('content', 'contributors').present? 
-    return true
+    return false unless has_draft?(section)
+
+    if stateable?
+      state == :published || parsed_draft['state'] == 'published'
+    elsif publishable?
+      published
+    else
+      true
+    end
   end
 
   def parsed_draft

--- a/app/models/concerns/draftable.rb
+++ b/app/models/concerns/draftable.rb
@@ -84,6 +84,16 @@ module Draftable
       end
     end
 
+    self.class.reflect_on_all_associations.each do |model|
+      puts "CHECK ASSOC #{model.name}"
+      next unless model.options[:draftable].present?
+
+      if send(model.name).any?(&:changed?)
+        puts "Association #{model.name} has changed"
+      end
+      binding.pry
+    end
+
     self[:draft] = (parsed_draft || {}).merge(new_draft)
   end
 

--- a/app/policies/admin/meditation_policy.rb
+++ b/app/policies/admin/meditation_policy.rb
@@ -12,19 +12,24 @@ module Admin
     end
 
     def update_translation?
-      manage?
+      return false unless can_access_locale?
+      manage? || (translator? && needs_translation?)
     end
 
     def update_structure?
       (manage? && super_admin?) || (create? && record.new_record?)
     end
 
-    def publish?
-      update?
-    end
-
     def create?
       manage?
+    end
+
+    def publish?
+      manage?
+    end
+
+    def review?
+      publish?
     end
 
   end

--- a/app/views/admin/application/_form.html.slim
+++ b/app/views/admin/application/_form.html.slim
@@ -2,7 +2,7 @@
 - allow = policy(record)
 
 - if record.draftable? && record.has_draft? && record.parsed_draft.except('content', 'contributors').present?
-  .ui.yellow.message = translate 'admin.messages.unpublished_changes_notice', page: human_model_name(record)
+  .ui.yellow.message = translate 'admin.messages.unapproved_changes_notice', page: human_model_name(record)
 
 - if record.is_a?(User) && record.pending_invitation?
   .ui.yellow.message = translate 'admin.messages.pending_invitation_notice', person: human_enum_name(record, :role).downcase

--- a/app/views/admin/fields/_meditation.html.slim
+++ b/app/views/admin/fields/_meditation.html.slim
@@ -2,8 +2,12 @@
 - allow = policy(record)
 
 - if allow.update_structure?
-  = f.association :duration_filter
-  = f.association :goal_filters
+  = draftable_field f, :duration_filter, type: :association do |value|
+    - f.association :duration_filter, wrapper: false, label: false, selected: value
+  p LIVE #{f.object.goal_filter_ids}
+  p DRAFT #{f.object.parsed_draft['goal_filter_ids']}
+  = draftable_field f, :goal_filters, type: :association do |value|
+    - f.association :goal_filters, wrapper: false, label: false, selected: value
 - else
   .preview-item
     div
@@ -15,43 +19,24 @@
       | #{human_attribute_name(record.class, :duration_filter)}: 
       = record.duration_filter.name
 
-= f.input :image, as: :file, wrapper: :semantic_file, icon: file_type_icon(:image), file: record.image, input_html: { accept: file_type_accepts(:image) }
-- if record.image.present?
-  .preview-item = image_tag record.image.url(:small), class: 'ui rounded image'
+= draftable_media_field f, :thumbnail, preview: true, wrapper: { required: true }
 
-= f.input :horizontal_vimeo_id, wrapper: :semantic_input, icon: :video, wrapper_html: { class: 'js-vimeo-field' }
-- vimeo_metadata = record.vimeo_metadata(:horizontal)
-.preview-item
-  = hidden_field_tag "#{f.object_name}[vimeo_metadata][horizontal]", vimeo_metadata.to_json
-  .reload
-    i.sync.icon
-    = translate 'admin.action.descriptive.reload_vimeo_data'
-  .content style=('display: none' unless vimeo_metadata.present?)
-    .ui.metadata.accordion
-      .title
-        i.dropdown.icon
-        = Meditation.human_attribute_name(:vimeo_metadata)
-      pre.raw.content = vimeo_metadata.pretty_inspect
-    .hint = vimeo_metadata[:title]
-    a.ui.image href="https://vimeo.com/#{record.horizontal_vimeo_id}" target='_blank'
-      img src=vimeo_metadata[:thumbnail]
+= draftable_field f, :horizontal_vimeo_id, type: :integer
+- if record.horizontal_vimeo_id.present?
+  .preview-item
+    a.ui.label.link href="https://vimeo.com/#{record.horizontal_vimeo_id}" target='_blank'
+      | vimeo.com/#{record.horizontal_vimeo_id}
+      i.external.alternate.icon
 
-= f.input :vertical_vimeo_id, wrapper: :semantic_input, icon: :video, wrapper_html: { class: 'js-vimeo-field' }
-- vimeo_metadata = record.vimeo_metadata(:vertical)
-.preview-item
-  = hidden_field_tag "#{f.object_name}[vimeo_metadata][vertical]", vimeo_metadata.to_json
-  .reload
-    i.sync.icon
-    = translate 'admin.action.descriptive.reload_vimeo_data'
-  .content style=('display: none' unless vimeo_metadata.present?)
-    .ui.metadata.accordion
-      .title
-        i.dropdown.icon
-        = Meditation.human_attribute_name(:vimeo_metadata)
-      pre.raw.content = vimeo_metadata.pretty_inspect
-    .hint = vimeo_metadata[:title]
-    a.ui.image href="https://vimeo.com/#{record.vertical_vimeo_id}" target='_blank'
-      img src=vimeo_metadata[:thumbnail]
+= draftable_field f, :vertical_vimeo_id, type: :integer
+- if record.vertical_vimeo_id.present?
+  .preview-item
+    a.ui.label.link href="https://vimeo.com/#{record.vertical_vimeo_id}" target='_blank'
+      | vimeo.com/#{record.vertical_vimeo_id}
+      i.external.alternate.icon
 
-= f.input :excerpt, as: :text
-= f.input :description, as: :text
+= draftable_field f, :excerpt, type: :text do |value|
+  - f.input_field :excerpt, as: :text, rows: 3, value: value
+
+= draftable_field f, :description, type: :text do |value|
+  - f.input_field :description, as: :text, rows: 5, value: value

--- a/config/locales/de/admin.yml
+++ b/config/locales/de/admin.yml
@@ -77,7 +77,7 @@ de:
     tags:
       published: "Published"
       unpublished: "Not Published"
-      unpublished_changes: "Has Unpublished Changes"
+      unapproved_changes: "Has Unapproved Changes"
       unpublished_draft: "Unpublished Draft"
       no_translation: "No %{language} Translation" # "language" will be replaced with the language that this file is written in.
       pending_translation: "Has %{language} Translation, Pending Approval" # "language" will be replaced with the language that this file is written in.
@@ -107,7 +107,7 @@ de:
       confirm_discard_draft: "Are you sure you want to discard all changes to this page? This cannot be undone!"
       confirm_unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave the page?"
       drop_files_here: "Drop files here"
-      unpublished_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
+      unapproved_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
       pending_invitation_notice: "This %{person} has been sent an invitation to become an editor on the website, but has not yet responded."
       draft_notice: "You are viewing a draft version of this %{page}. This version not be visible to the public until it has been reviewed by an administrator."
       draft_contributed_by: "This draft includes changed made by %{people}."

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -78,7 +78,7 @@ en:
     tags:
       published: "Published"
       unpublished: "Not Published"
-      unpublished_changes: "Has Unpublished Changes"
+      unapproved_changes: "Has Unapproved Changes"
       unpublished_draft: "Unpublished Draft"
       no_translation: "No %{language} Translation" # "language" will be replaced with the language that this file is written in.
       pending_translation: "Has %{language} Translation, Pending Approval" # "language" will be replaced with the language that this file is written in.
@@ -108,7 +108,7 @@ en:
       confirm_discard_draft: "Are you sure you want to discard all changes to this page? This cannot be undone!"
       confirm_unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave the page?"
       drop_files_here: "Drop files here"
-      unpublished_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
+      unapproved_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
       pending_invitation_notice: "This %{person} has been sent an invitation to become an editor on the website, but has not yet responded."
       draft_notice: "You are viewing a draft version of this %{page}. This version not be visible to the public until it has been reviewed by an administrator."
       draft_contributed_by: "This draft includes changed made by %{people}."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -78,7 +78,7 @@ es:
     tags:
       published: "Published"
       unpublished: "Not Published"
-      unpublished_changes: "Has Unpublished Changes"
+      unapproved_changes: "Has Unapproved Changes"
       unpublished_draft: "Unpublished Draft"
       no_translation: "No %{language} Translation" # "language" will be replaced with the language that this file is written in.
       pending_translation: "Has %{language} Translation, Pending Approval" # "language" will be replaced with the language that this file is written in.
@@ -108,7 +108,7 @@ es:
       confirm_discard_draft: "Are you sure you want to discard all changes to this page? This cannot be undone!"
       confirm_unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave the page?"
       drop_files_here: "Drop files here"
-      unpublished_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
+      unapproved_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
       pending_invitation_notice: "This %{person} has been sent an invitation to become an editor on the website, but has not yet responded."
       draft_notice: "You are viewing a draft version of this %{page}. This version not be visible to the public until it has been reviewed by an administrator."
       draft_contributed_by: "This draft includes changed made by %{people}."

--- a/config/locales/fr/admin.yml
+++ b/config/locales/fr/admin.yml
@@ -78,7 +78,7 @@ fr:
     tags:
       published: "Published"
       unpublished: "Not Published"
-      unpublished_changes: "Has Unpublished Changes"
+      unapproved_changes: "Has Unapproved Changes"
       unpublished_draft: "Unpublished Draft"
       no_translation: "No %{language} Translation" # "language" will be replaced with the language that this file is written in.
       pending_translation: "Has %{language} Translation, Pending Approval" # "language" will be replaced with the language that this file is written in.
@@ -108,7 +108,7 @@ fr:
       confirm_discard_draft: "Are you sure you want to discard all changes to this page? This cannot be undone!"
       confirm_unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave the page?"
       drop_files_here: "Drop files here"
-      unpublished_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
+      unapproved_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
       pending_invitation_notice: "This %{person} has been sent an invitation to become an editor on the website, but has not yet responded."
       draft_notice: "You are viewing a draft version of this %{page}. This version not be visible to the public until it has been reviewed by an administrator."
       draft_contributed_by: "This draft includes changed made by %{people}."

--- a/config/locales/hy/admin.yml
+++ b/config/locales/hy/admin.yml
@@ -78,7 +78,7 @@ hy:
     tags:
       published: "Published"
       unpublished: "Not Published"
-      unpublished_changes: "Has Unpublished Changes"
+      unapproved_changes: "Has Unapproved Changes"
       unpublished_draft: "Unpublished Draft"
       no_translation: "No %{language} Translation" # "language" will be replaced with the language that this file is written in.
       pending_translation: "Has %{language} Translation, Pending Approval" # "language" will be replaced with the language that this file is written in.
@@ -108,7 +108,7 @@ hy:
       confirm_discard_draft: "Are you sure you want to discard all changes to this page? This cannot be undone!"
       confirm_unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave the page?"
       drop_files_here: "Drop files here"
-      unpublished_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
+      unapproved_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
       pending_invitation_notice: "This %{person} has been sent an invitation to become an editor on the website, but has not yet responded."
       draft_notice: "You are viewing a draft version of this %{page}. This version not be visible to the public until it has been reviewed by an administrator."
       draft_contributed_by: "This draft includes changed made by %{people}."

--- a/config/locales/it/admin.yml
+++ b/config/locales/it/admin.yml
@@ -76,7 +76,7 @@ it:
     tags:
       published: "Pubblicato"
       unpublished: "Non ancora pubblicato"
-      unpublished_changes: "Ci sono cambiamenti non pubblicati"
+      unapproved_changes: "Has Unapproved Changes" # TODO: Translate
       unpublished_draft: "Anteprima non pubblicata"
       no_translation: "Traduzione %{language} mancante"
       pending_translation: "Traduzione %{language} presente, da approvare."
@@ -106,7 +106,7 @@ it:
       confirm_discard_draft: "Are you sure you want to discard all changes shown on this page? This cannot be undone!" # TODO: Translate
       confirm_unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave the page?" # TODO: Translate
       drop_files_here: "Trascina i documenti qui."
-      unpublished_changes_notice: "%{page} ha delle modifiche non pubblicate. Questi cambiamenti non saranno visibili fino a quando un amministratore non li avrà rivisti."
+      unapproved_changes_notice: "%{page} ha delle modifiche non pubblicate. Questi cambiamenti non saranno visibili fino a quando un amministratore non li avrà rivisti."
       pending_invitation_notice: "%{person} è stato invitato/a ad essere editore di WeMeditate, ma non ha ancora risposto."
       draft_notice: "Sati vedendo un'anteprima di %{page}. Questa versione non sarà visibile fino a quando un amministratore non l'avrà rivista."
       draft_contributed_by: "Quest'anteprima include dei cambiamenti effettuati da %{people}."

--- a/config/locales/nl/admin.yml
+++ b/config/locales/nl/admin.yml
@@ -78,7 +78,7 @@ nl:
     tags:
       published: "Published"
       unpublished: "Not Published"
-      unpublished_changes: "Has Unpublished Changes"
+      unapproved_changes: "Has Unapproved Changes"
       unpublished_draft: "Unpublished Draft"
       no_translation: "No %{language} Translation" # "language" will be replaced with the language that this file is written in.
       pending_translation: "Has %{language} Translation, Pending Approval" # "language" will be replaced with the language that this file is written in.
@@ -108,7 +108,7 @@ nl:
       confirm_discard_draft: "Are you sure you want to discard all changes to this page? This cannot be undone!"
       confirm_unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave the page?"
       drop_files_here: "Drop files here"
-      unpublished_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
+      unapproved_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
       pending_invitation_notice: "This %{person} has been sent an invitation to become an editor on the website, but has not yet responded."
       draft_notice: "You are viewing a draft version of this %{page}. This version not be visible to the public until it has been reviewed by an administrator."
       draft_contributed_by: "This draft includes changed made by %{people}."

--- a/config/locales/pt/admin.yml
+++ b/config/locales/pt/admin.yml
@@ -78,7 +78,7 @@ pt:
     tags:
       published: "Published"
       unpublished: "Not Published"
-      unpublished_changes: "Has Unpublished Changes"
+      unapproved_changes: "Has Unapproved Changes"
       unpublished_draft: "Unpublished Draft"
       no_translation: "No %{language} Translation" # "language" will be replaced with the language that this file is written in.
       pending_translation: "Has %{language} Translation, Pending Approval" # "language" will be replaced with the language that this file is written in.
@@ -108,7 +108,7 @@ pt:
       confirm_discard_draft: "Are you sure you want to discard all changes to this page? This cannot be undone!"
       confirm_unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave the page?"
       drop_files_here: "Drop files here"
-      unpublished_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
+      unapproved_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
       pending_invitation_notice: "This %{person} has been sent an invitation to become an editor on the website, but has not yet responded."
       draft_notice: "You are viewing a draft version of this %{page}. This version not be visible to the public until it has been reviewed by an administrator."
       draft_contributed_by: "This draft includes changed made by %{people}."

--- a/config/locales/ru/admin.yml
+++ b/config/locales/ru/admin.yml
@@ -78,7 +78,7 @@ ru:
     tags:
       published: "Опубликовано"
       unpublished: "Не опубликовано"
-      unpublished_changes: "Есть неопубликованные изменения"
+      unapproved_changes: "Has Unapproved Changes" # TODO: Translate
       unpublished_draft: "Неопубликованный черновик"
       no_translation: "Отсутствует перевод на %{language}" # "language" will be replaced with the language that this file is written in.
       pending_translation: "Есть перевод на %{language}, в ожидании утверждения" # "language" will be replaced with the language that this file is written in.
@@ -110,7 +110,7 @@ ru:
       confirm_discard_draft: "Вы уверены, что хотите отменить правки, показанные на этой странице? Действие невозможно будет отменить!" 
       confirm_unsaved_changes: "Подождите! Несохраненные данные будут потеряны. Вы уверены, что хотите покинуть страницу?"
       drop_files_here: "Переместите файлы сюда"
-      unpublished_changes_notice: "%{page} имеет несохраненные изменения. Изменения не видны пользователям, пока они не утверждены администратором."
+      unapproved_changes_notice: "%{page} имеет несохраненные изменения. Изменения не видны пользователям, пока они не утверждены администратором."
       pending_invitation_notice: "%{person} получил приглашение стать редактором сайта, но ещё не ответил."
       draft_notice: "Вы просматриваете черновик %{page}. Эта версия не видна пользователям, пока они не утверждена администратором."
       draft_contributed_by: "Этот черновик содержит изменения, сделанные %{people}."

--- a/config/locales/uk/admin.yml
+++ b/config/locales/uk/admin.yml
@@ -78,7 +78,7 @@ uk:
     tags:
       published: "Published"
       unpublished: "Not Published"
-      unpublished_changes: "Has Unpublished Changes"
+      unapproved_changes: "Has Unapproved Changes"
       unpublished_draft: "Unpublished Draft"
       no_translation: "No %{language} Translation" # "language" will be replaced with the language that this file is written in.
       pending_translation: "Has %{language} Translation, Pending Approval" # "language" will be replaced with the language that this file is written in.
@@ -109,7 +109,7 @@ uk:
       confirm_discard_draft: "Are you sure you want to discard all changes to this page? This cannot be undone!"
       confirm_unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave the page?"
       drop_files_here: "Drop files here"
-      unpublished_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
+      unapproved_changes_notice: "This %{page} has unpublished changes. These will not be visible to the public until they have been reviewed by an administrator."
       pending_invitation_notice: "This %{person} has been sent an invitation to become an editor on the website, but has not yet responded."
       draft_notice: "You are viewing a draft version of this %{page}. This version not be visible to the public until it has been reviewed by an administrator."
       draft_contributed_by: "This draft includes changed made by %{people}."

--- a/db/migrate/20191021131702_add_draft_to_meditations.rb
+++ b/db/migrate/20191021131702_add_draft_to_meditations.rb
@@ -1,0 +1,6 @@
+class AddDraftToMeditations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :meditation_translations, :draft, :jsonb
+    add_column :meditation_translations, :thumbnail_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_20_153439) do
+ActiveRecord::Schema.define(version: 2019_10_21_131702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -229,6 +229,8 @@ ActiveRecord::Schema.define(version: 2019_10_20_153439) do
     t.float "popularity", default: 0.0, null: false
     t.jsonb "vimeo_metadata"
     t.integer "state", default: 0
+    t.jsonb "draft"
+    t.integer "thumbnail_id"
     t.index ["locale"], name: "index_meditation_translations_on_locale"
     t.index ["meditation_id"], name: "index_meditation_translations_on_meditation_id"
   end


### PR DESCRIPTION
This is a partially implemented solution which would make meditations draftable, and thus allow us to let translators have access Meditations.

However, this has run into a snag because the `goal_filters` association is not draftable. We don't have a solution for allowing `has_many` relationships to be drafted. It's a rather complicated process because the relationship is not stored directly on the `meditation` model.

Until that issue is resolved this cannot be implemented.

(The branch name is a mistake, it should say `draftable-meditations`)