### PR TITLE
Add .hound.yml to ensure HoundCI uses the correct rubocop config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml


### PR DESCRIPTION
Seems kind of redundant but whatever 🤷‍♂ 