### PR TITLE
Specify rubocop version 0.75.0 in .hound.yml

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,6 @@
-ruby:
+# This is the config file for HoundCI (https://houndci.com) providing
+# automated style guide linting on our Pull Requests.
+
+rubocop:
   config_file: .rubocop.yml
+  version: 0.75.0 # http://help.houndci.com/en/articles/2461415-supported-linters


### PR DESCRIPTION
0.76.0 is not yet supported but 0.75 is good enough for our current configuration…

This change is confirmed to be working on https://github.com/sydevs/WeMeditate/pull/34