### PR TITLE
Rollbar: Ignore RoutingError and report async

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -25,14 +25,19 @@ Rollbar.configure do |config|
   # via the rollbar interface.
   # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
   # 'ignore' will cause the exception to not be reported at all.
-  # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
-  #
+
+  config.exception_level_filters.merge!(
+    'ActionController::RoutingError' => 'ignore'
+  )
+
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
 
   # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
   # is not installed)
-  # config.use_async = true
+
+  config.use_async = true
+
   # Supply your own async handler:
   # config.async_handler = Proc.new { |payload|
   #  Thread.new { Rollbar.process_from_async_handler(payload) }


### PR DESCRIPTION
We’re overflowing with RoutingError right now so might be best to disable it for now, could re-enable it once we have more credits to work with.

Async should be turned on to avoid stalling 500 pages in case the Rollbar is slow to respond or even unavailable.