### PR TITLE
Support google cloud bucket asset host

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -5,6 +5,13 @@ CarrierWave.configure do |config|
     config.storage = :gcloud
     config.gcloud_bucket = ENV['GCLOUD_BUCKET']
 
+    # If the bucket name looks like a host name use it as asset_host.
+    # For example "wemeditate" is treated as bucket only with URL's like:
+    # https://storage.googleapis.com/wemeditate/uploads/<carrier-wave-path>
+    # while "assets.wemeditate.co" is treated as a host with URL's like:
+    # https://assets.wemeditate.co/uploads/<carrier-wave-path>
+    config.asset_host = "https://#{ENV['GCLOUD_BUCKET']}" if ENV['GCLOUD_BUCKET'].include?('.')
+
     config.gcloud_bucket_is_public = true
     config.gcloud_authenticated_url_expiration = 600
 


### PR DESCRIPTION
Changes URL's from `https://storage.googleapis.com/assets.wemeditate.co/<carrier-wave-path>` to `https://assets.wemeditate.co/wemeditate/<carrier-wave-path>`. This allows us to use CloudFlare as a CDN and caching layer for all our carrierwave assets.

Found the configuration option by looking at the `carrierwave-google-storage` source since it wasn't actually mentioned in the README: https://github.com/metaware/carrierwave-google-storage/blob/f6aa3504a57aa4c501edced69b75e32498697098/lib/carrierwave/storage/gcloud_file.rb#L85