### PR TITLE
Support any host in development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,4 +66,7 @@ Rails.application.configure do
 
   # For letter opener
   config.action_mailer.delivery_method = :letter_opener
+
+  # Allow using any host for the rails server (eg. to support puma-dev)
+  config.hosts.clear
 end


### PR DESCRIPTION
Rails 6 introduced extra security around host name protection. By default only “localhost” is allowed in development. However when using puma-dev (spiritual successor to pow) and running rails under wemeditate.test or similar Rails will raise an error:

<img width="880" alt="Screenshot 2020-05-08 at 11 38 22" src="https://user-images.githubusercontent.com/3461/81393320-766c2000-9120-11ea-9926-f5ce2970c94b.png">

Rather than explicitly configure host names it makes more sense to me to just clear the hosts to avoid grief for developers with different preferences. The security vulnerability here is quite theoretical in nature and can't happen even in production since Heroku router would make it impossible to exploit. In the development environment it's just a non-issue.

BTW I'm sort of confused as to why our production environment isn't complaining about this. Perhaps `route_translator` gem automatically whitelists configured hosts or something?