### PR TITLE
Fix db:create / db:drop etc breaking due to boot time column_names call

### DIFF
--- a/app/models/concerns/contentable.rb
+++ b/app/models/concerns/contentable.rb
@@ -12,7 +12,9 @@ module Contentable
   included do |base|
     %i[content].each do |column|
       next if base.try(:translated_attribute_names)&.include?(column) || base.column_names.include?(column.to_s)
-      throw "Column `#{column}` must be defined to make the `#{base.model_name}` model `Contentable`" 
+      throw "Column `#{column}` must be defined to make the `#{base.model_name}` model `Contentable`"
+    rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid # rubocop:disable Lint/HandleExceptions
+      # avoid breaking rails db:create / db:drop etc due to boot time execution
     end
 
     base.has_many :media_files, as: :page, inverse_of: :page, dependent: :delete_all

--- a/app/models/concerns/draftable.rb
+++ b/app/models/concerns/draftable.rb
@@ -4,17 +4,19 @@
 module Draftable
 
   extend ActiveSupport::Concern
-  
+
   def draftable?
     true
   end
 
   included do |base|
     translatable = base.respond_to?(:translated_attribute_names)
-    
+
     %i[draft].each do |column|
       next if base.try(:translated_attribute_names)&.include?(column) || base.column_names.include?(column.to_s)
-      throw "Column `#{column}` must be defined to make the `#{base.model_name}` model `Draftable`" 
+      throw "Column `#{column}` must be defined to make the `#{base.model_name}` model `Draftable`"
+    rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid # rubocop:disable Lint/HandleExceptions
+      # avoid breaking rails db:create / db:drop etc due to boot time execution
     end
 
     if translatable
@@ -169,7 +171,7 @@ module Draftable
     else
       discard_draft! discard: %i[content]
     end
-    
+
     write_attribute :content, new_live_content
     #binding.pry
   end

--- a/app/models/concerns/stateable.rb
+++ b/app/models/concerns/stateable.rb
@@ -17,8 +17,9 @@ module Stateable
 
     %i[state published_at].each do |column|
       next if base.try(:translated_attribute_names)&.include?(column) || base.column_names.include?(column.to_s)
-
       throw "Column `#{column}` must be defined to make the `#{base.model_name}` model `Stateable`"
+    rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid # rubocop:disable Lint/HandleExceptions
+      # avoid breaking rails db:create / db:drop etc due to boot time execution
     end
 
     base.enum state: {

--- a/app/models/concerns/viewable.rb
+++ b/app/models/concerns/viewable.rb
@@ -14,7 +14,9 @@ module Viewable
 
     %i[slug metatags].each do |column|
       next if base.try(:translated_attribute_names)&.include?(column) || base.column_names.include?(column.to_s)
-      throw "Column `#{column}` must be defined to make the `#{base.model_name}` model `Viewable`" 
+      throw "Column `#{column}` must be defined to make the `#{base.model_name}` model `Viewable`"
+    rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid # rubocop:disable Lint/HandleExceptions
+      # avoid breaking rails db:create / db:drop etc due to boot time execution
     end
 
     base.extend FriendlyId


### PR DESCRIPTION
This unbreaks setting up the database in both development and CI environments and fixes the issue mentioned in https://github.com/sydevs/WeMeditate/issues/15#issuecomment-660668299

I haven’t looked into at what point these models + concerns started getting eagerly loaded at boot time. The stracktrace hints that the lookup_helper.rb file which explicitly refers to the model constants is part of the problem: https://github.com/sydevs/WeMeditate/blob/627305a0638fe184d661eb9700d9f50d65fb3b88/app/helpers/admin/lookup_helper.rb#L38-L52

However not sure if eagerly loading helpers at boot is normal Rails behaviour or not.

In any case rescuing all these database calls fixes the issue.