### PR TITLE
Bypass 30s heroku request timeout in media file upload controller

### DIFF
--- a/app/controllers/admin/media_files_controller.rb
+++ b/app/controllers/admin/media_files_controller.rb
@@ -15,6 +15,9 @@ module Admin
       end
 
       authorize @parent, :upload?
+      @media_file = @parent.media_files.build params.permit(:file)
+
+      return render json: { errors: @media_file.errors }, status: 422 unless @media_file.validate
 
       # Bypass Heroku's 30s request timeout by treating it as a streaming response:
       # https://devcenter.heroku.com/articles/request-timeout#long-polling-and-streaming-responses
@@ -32,7 +35,7 @@ module Admin
       end
 
       # Transcodes multiple versions of the uploaded image which gets time consuming for large images
-      @media_file = @parent.media_files.create! params.permit(:file)
+      @media_file.save!
 
       response_keep_alive_thread.kill
 

--- a/app/controllers/admin/media_files_controller.rb
+++ b/app/controllers/admin/media_files_controller.rb
@@ -1,6 +1,8 @@
 module Admin
   class MediaFilesController < Admin::ApplicationController
 
+    include ActionController::Live
+
     def create
       if params[:article_id].present?
         @parent = Article.friendly.find(params[:article_id])
@@ -13,9 +15,31 @@ module Admin
       end
 
       authorize @parent, :upload?
-      @media_file = @parent.media_files.create! params.permit(:file)
-      render json: { id: @media_file.id, preview: @media_file.file.small.url }.to_json
-    end
 
+      # Bypass Heroku's 30s request timeout by treating it as a streaming response:
+      # https://devcenter.heroku.com/articles/request-timeout#long-polling-and-streaming-responses
+      headers['Content-Type'] = 'application/json'
+      # Prevent Rack::ETag from killing the streaming response: https://git.io/Jk5i0
+      headers['Last-Modified'] = '0'
+      response_keep_alive_thread = Thread.new do
+        loop do
+          sleep 1
+          response.stream.write "\n"
+        rescue IOError => e
+          Rails.logger.warn "IOError while writing to streaming response in MediaFilesController#create: #{e.message}"
+          break
+        end
+      end
+
+      # Transcodes multiple versions of the uploaded image which gets time consuming for large images
+      @media_file = @parent.media_files.create! params.permit(:file)
+
+      response_keep_alive_thread.kill
+
+      response_json = { id: @media_file.id, preview: @media_file.file.small.url }.to_json
+      response.stream.write(response_json)
+    ensure
+      response.stream.close
+    end
   end
 end


### PR DESCRIPTION
By using a streaming response we can bypass Heroku’s 30s request timeout as documented at: https://devcenter.heroku.com/articles/request-timeout#long-polling-and-streaming-responses

Proof of concept from this branch running on `wemeditate-staging´:
<img width="1791" alt="Screenshot 2020-11-27 at 19 09 59" src="https://user-images.githubusercontent.com/3461/100475805-51eb8b80-30e4-11eb-8f0d-8cffca698ddb.png">

With a 40 megapixel image I could keep the request going for ~7min until completed so this can handle any crazy image.

**Known issues:**
If the user uploads a file which isn't an image `@parent.media_files.create!` will raise `ActiveRecord::RecordInvalid`, but when we stream we have to commit to a HTTP status before starting to stream the body, ie. 200. So the frontend client gets confused as a 200 OK response comes back without any JSON data so it decides to render a broken image:
<img width="694" alt="Screenshot 2020-11-27 at 19 15 35" src="https://user-images.githubusercontent.com/3461/100476064-efdf5600-30e4-11eb-9473-51a29167d085.png">

This could be improved by teaching the client to not trust the HTTP status but instead determine success based on the JSON payload returned. Or perhaps we could do a quick sanity check on the uploaded file before running `create!` at which point we could still bail out with an error code without worrying about the timeout.