### PR TITLE
Add asset version query string for asset URL’s

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,19 @@
 LOCALHOST=lvh.me # recognized as a proper domain but points to 127.0.0.1 (https://thoughtbot.com/blog/acceptance-tests-with-subdomains)
+
+# We add Google Cloud configuration to ensure Carrierwave is initialized
+# with the gcloud adapter to allow us to test the integration.
+# Note: Private key is a mock RSA key, doesn't actually exist at Google.
+GCLOUD_BUCKET=assets.wemeditate.test
+GOOGLE_CLOUD_PROJECT=wemeditate
+GOOGLE_CLOUD_KEYFILE='{
+  "type": "service_account",
+  "project_id": "wemeditate",
+  "private_key_id": "foo",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUp\nwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ5\n1s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQABAoGAFijko56+qGyN8M0RVyaRAXz++xTqHBLh\n3tx4VgMtrQ+WEgCjhoTwo23KMBAuJGSYnRmoBZM3lMfTKevIkAidPExvYCdm5dYq3XToLkkLv5L2\npIIVOFMDG+KESnAFV7l2c+cnzRMW0+b6f8mR1CJzZuxVLL6Q02fvLi55/mbSYxECQQDeAw6fiIQX\nGukBI4eMZZt4nscy2o12KyYner3VpoeE+Np2q+Z3pvAMd/aNzQ/W9WaI+NRfcxUJrmfPwIGm63il\nAkEAxCL5HQb2bQr4ByorcMWm/hEP2MZzROV73yF41hPsRC9m66KrheO9HPTJuo3/9s5p+sqGxOlF\nL0NDt4SkosjgGwJAFklyR1uZ/wPJjj611cdBcztlPdqoxssQGnh85BzCj/u3WqBpE2vjvyyvyI5k\nX6zk7S0ljKtt2jny2+00VsBerQJBAJGC1Mg5Oydo5NwD6BiROrPxGo2bpTbu/fhrT8ebHkTz2epl\nU9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ\n37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=\n-----END RSA PRIVATE KEY-----\n",
+  "client_email": "carrierwave-upload@wemeditate.iam.gserviceaccount.com",
+  "client_id": "108",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/carrierwave-upload%40wemeditate.iam.gserviceaccount.com"
+}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - bundle install --deployment -j 4
   - bundle exec rails db:create db:schema:load
   - bundle exec rails runner "Webdrivers::Chromedriver.update" # prepares chromedriver via webdrivers gem
-script: bundle exec rails test:system
+script: bundle exec rails test:system test

--- a/Gemfile
+++ b/Gemfile
@@ -121,5 +121,9 @@ group :development do
   gem 'web-console'
 end
 
+group :test do
+  gem 'webmock'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
       rails (>= 5.0, < 6.1.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.8)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     debug_inspector (0.0.3)
     declarative (0.0.20)
@@ -208,6 +210,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
+    hashdiff (1.0.1)
     httparty (0.18.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -441,6 +444,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.13.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
@@ -530,6 +537,7 @@ DEPENDENCIES
   uglifier
   web-console
   webdrivers
+  webmock
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -1,0 +1,14 @@
+# Monkey patch the carrierwave-google-storage gem to include assets version
+# for URL's. Was added in July 2021 to bust a hidden cache within Google Cloud
+# Storage which prevented CORS headers from appearing.
+
+module GcloudUrlWithAssetVersionQueryString
+
+  # The handle_options method gets called by all methods setting and deleting cookies
+  def public_url
+    "#{super}?version=#{Rails.application.config.assets.version}"
+  end
+
+end
+
+CarrierWave::Storage::GcloudFile.prepend GcloudUrlWithAssetVersionQueryString

--- a/test/initializers/monkey_patches_test.rb
+++ b/test/initializers/monkey_patches_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class MonkeyPatchesTest < ActiveSupport::TestCase
+
+  test 'public_url of GcloudFile uploads includes asset version query string' do
+    CarrierWave.configure do |config|
+      config.storage = :gcloud
+    end
+
+    stub_request(:post, 'https://oauth2.googleapis.com/token')
+      .to_return(
+        status: 200,
+        body: { access_token: 'foo', refresh_token: 'bar' }.to_json,
+        headers: { "Content-Type": 'application/json' }
+      )
+    file_name = 'test.svg'
+    result = MediaFile.insert(
+      file: file_name,
+      page_type: 'StaticPage',
+      page_id: 1,
+      image_meta: { width: 640, height: 480 }.to_json,
+      created_at: Time.now,
+      updated_at: Time.now
+    )
+
+    media_file = MediaFile.find(result.first.fetch('id'))
+
+    host = "https://#{ENV.fetch('GCLOUD_BUCKET')}"
+    query_string = "version=#{Rails.application.config.assets.version}"
+    expected_url = "#{host}/uploads/media_file/file/#{media_file.id}/#{file_name}?#{query_string}"
+
+    assert_equal expected_url, media_file.file.url
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,9 @@
 require_relative '../config/environment'
 require 'rails/test_help'
+require 'webmock/minitest'
+
+# Open up localhost connections for system tests to work out
+WebMock.disable_net_connect!(allow_localhost: true)
 
 class ActiveSupport::TestCase
 


### PR DESCRIPTION
Allows us to bypass some kind of caching issue in Google Cloud Storage which prevents assets from responding with the correct CORS headers.

Example:
<img width="1335" alt="Screenshot 2021-07-02 at 16 45 03" src="https://user-images.githubusercontent.com/3461/124302874-07daf480-db62-11eb-92c3-50040e1ebae8.png">
