### PR TITLE
Changed "not translated" warning in French

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -121,7 +121,7 @@ fr:
     share: "Partager: "
 
   meditations:
-    not_translated: "Les méditations n'ont pas encore été enregistrées en français. Veuillez nous excuser. Nous espérons les publier bientôt."
+    not_translated: "Certaines vidéos sont encore en anglais, merci de patienter. Nous espérons les publier bientôt en français."
     title: "Méditations"
     prescreen:
       title: "Accédez aux méditations guidées après avoir éveillé votre %{kundalini} "


### PR DESCRIPTION
French regional admin requested to change the "not translated" warning because some of the meditations are already in French.